### PR TITLE
Docker tweaks

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,8 +10,8 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
     && echo $TZ > /etc/timezone \
     && chmod +x /entrypoint.sh
 
-RUN apt-get update \
-    && apt-get install -y \
+RUN apt-get update --quiet --quiet \
+    && apt-get install --yes \
         inkscape \
         gettext-base \
         python-qrcode \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,9 @@ RUN apt-get update \
         gettext-base \
         python-qrcode \
         pdftk \
-        make
+        make \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /data
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,12 +11,13 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
     && chmod +x /entrypoint.sh
 
 RUN apt-get update --quiet --quiet \
-    && apt-get install --yes \
-        inkscape \
+    && apt-get install --yes --no-install-recommends \
         gettext-base \
-        python-qrcode \
-        pdftk \
+        inkscape \
         make \
+        pdftk \
+        python-qrcode \
+        python-scour \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,8 +6,17 @@ COPY entrypoint.sh /
 
 ENV TZ=Europe/Paris
 
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone  && chmod +x /entrypoint.sh
-RUN apt-get update && apt-get install -y inkscape gettext-base python-qrcode pdftk make
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime \
+    && echo $TZ > /etc/timezone \
+    && chmod +x /entrypoint.sh
+
+RUN apt-get update \
+    && apt-get install -y \
+        inkscape \
+        gettext-base \
+        python-qrcode \
+        pdftk \
+        make
 
 WORKDIR /data
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:9
+FROM debian:9-slim
 
 VOLUME ["/data"]
 


### PR DESCRIPTION
Différents tweaks sur le Dockerfile, ayant pour but d'alléger l'image finale : 
* une Debian plus légère
* on évite d'installer la terre entière
* on nettoie un chouille derrière soi

La taille passe de 676Mo à 365Mo, et le temp de build passe de 3m10s à 2m1s.